### PR TITLE
DATAGEODE-87 - Add enumeration for eviction attributes

### DIFF
--- a/src/main/resources/org/springframework/data/gemfire/config/spring-geode-2.1.xsd
+++ b/src/main/resources/org/springframework/data/gemfire/config/spring-geode-2.1.xsd
@@ -1425,31 +1425,7 @@ Regular expression based interest. If the pattern is '.*' then all keys of any t
 							</xsd:complexType>
 						</xsd:element>
 					</xsd:choice>
-					<xsd:element name="eviction" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation><![CDATA[
-Eviction policy for the partitioned region.
-								]]></xsd:documentation>
-						</xsd:annotation>
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="evictionType">
-									<xsd:attribute name="action" type="xsd:string" default="LOCAL_DESTROY">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
-Set to one of the following Eviction Actions:
-
-LOCAL_DESTROY - Entry is destroyed locally. Not available for Replicated Regions.
-
-OVERFLOW_TO_DISK - Entry is overflowed to disk and the value set to null in memory. For Partitioned Regions,
-this provides the most reliable read behavior across the region.
-											]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
+					<xsd:element name="eviction" type="evictionType" minOccurs="0" maxOccurs="1"/>
 					<xsd:group ref="subRegionGroup" minOccurs="0" maxOccurs="unbounded"/>
 				</xsd:sequence>
 				<xsd:attribute name="concurrency-level">
@@ -1577,31 +1553,7 @@ Defines a GemFire Local Region instance. Each Local Region is scoped only to the
 		<xsd:complexContent>
 			<xsd:extension base="baseRegionType">
 				<xsd:sequence minOccurs="1" maxOccurs="1">
-					<xsd:element name="eviction" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation><![CDATA[
-Eviction policy for the replicated region.
-                                ]]></xsd:documentation>
-						</xsd:annotation>
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="evictionType">
-									<xsd:attribute name="action" type="xsd:string">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
-Set to one of the following Eviction Actions:
-
-LOCAL_DESTROY - Entry is destroyed locally. Not available for Replicated Regions.
-
-OVERFLOW_TO_DISK - Entry is overflowed to disk and the value set to null in memory. For Partitioned Regions,
-this provides the most reliable read behavior across the region.
-											]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
+					<xsd:element name="eviction" type="evictionType" minOccurs="0" maxOccurs="1"/>
 					<xsd:group ref="subRegionGroup" minOccurs="0" maxOccurs="unbounded" />
 				</xsd:sequence>
 				<xsd:attribute name="concurrency-level">
@@ -1794,31 +1746,7 @@ Subscription policy for the partitioned region.
 							<xsd:attribute name="type" type="xsd:string" use="optional"/>
 						</xsd:complexType>
 					</xsd:element>
-					<xsd:element name="eviction" minOccurs="0" maxOccurs="1">
-						<xsd:annotation>
-							<xsd:documentation><![CDATA[
-Eviction policy for the partitioned region.
-								]]></xsd:documentation>
-						</xsd:annotation>
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="evictionType">
-									<xsd:attribute name="action" type="xsd:string" default="LOCAL_DESTROY">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
-Set to one of the following Eviction Actions:
-
-LOCAL_DESTROY - Entry is destroyed locally. Not available for Replicated Regions.
-
-OVERFLOW_TO_DISK - Entry is overflowed to disk and the value set to null in memory. For Partitioned Regions,
-this provides the most reliable read behavior across the region.
-											]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
+					<xsd:element name="eviction" type="evictionType" minOccurs="0" maxOccurs="1"/>
 				</xsd:sequence>
 				<xsd:attributeGroup ref="distributedRegionAttributes" />
 				<xsd:attribute name="copies" type="xsd:string" use="optional">
@@ -2002,20 +1930,41 @@ Eviction policy for the replicated region.
                                 ]]></xsd:documentation>
 						</xsd:annotation>
 						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="evictionType">
-									<xsd:attribute name="action" type="xsd:string" fixed="OVERFLOW_TO_DISK">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+						<xsd:attribute name="action" type="xsd:string" fixed="OVERFLOW_TO_DISK">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
 Set to the following Eviction Actions (Note LOCAL_DESTROY is not available for Replicated Regions):
 
 OVERFLOW_TO_DISK - Entry is overflowed to disk and the value set to null in memory. For Partitioned Regions,
 this provides the most reliable read behavior across the region.
 											]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="threshold" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+The threshold (or limit) against which the eviction algorithm runs. Once the threshold is reached, eviction is performed.
+				]]></xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="type">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+The 'type' of eviction performed, or algorithm used to perform eviction on the Region entries.  Eviction types include:
+ENTRY_COUNT: Considers the number of entries in the Region before performing an eviction. This is the default if no
+'type' attribute is set.
+HEAP_PERCENTAGE: Considers the amount of heap used (through the GemFire resource manager) before performing an eviction.
+MEMORY_SIZE: Considers the amount of memory consumed by the Region before performing an eviction.
+				]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:simpleType>
+								<xsd:restriction base="xsd:string">
+									<xsd:enumeration value="ENTRY_COUNT"/>
+									<xsd:enumeration value="HEAP_PERCENTAGE"/>
+									<xsd:enumeration value="MEMORY_SIZE"/>
+								</xsd:restriction>
+							</xsd:simpleType>
+						</xsd:attribute>
 						</xsd:complexType>
 					</xsd:element>
 					<xsd:group ref="subRegionGroup" minOccurs="0" maxOccurs="unbounded"/>
@@ -2272,16 +2221,42 @@ The threshold (or limit) against which the eviction algorithm runs. Once the thr
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="type" type="xsd:string" default="ENTRY_COUNT">
+		<xsd:attribute name="type" default="ENTRY_COUNT">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 The 'type' of eviction performed, or algorithm used to perform eviction on the Region entries.  Eviction types include:
-ENTRY_COUNT: Considers the number of entries in the Region before performing an eviction.
+ENTRY_COUNT: Considers the number of entries in the Region before performing an eviction. This is the default if no
+'type' attribute is set.
 HEAP_PERCENTAGE: Considers the amount of heap used (through the GemFire resource manager) before performing an eviction.
 MEMORY_SIZE: Considers the amount of memory consumed by the Region before performing an eviction.
 				]]></xsd:documentation>
 			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="ENTRY_COUNT"/>
+					<xsd:enumeration value="HEAP_PERCENTAGE"/>
+					<xsd:enumeration value="MEMORY_SIZE"/>
+				</xsd:restriction>
+			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="action">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Set to one of the following Eviction Actions:
+
+LOCAL_DESTROY - Entry is destroyed locally. Not available for Replicated Regions.
+
+OVERFLOW_TO_DISK - Entry is overflowed to disk and the value set to null in memory. For Partitioned Regions,
+this provides the most reliable read behavior across the region.
+											]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="LOCAL_DESTROY"/>
+						<xsd:enumeration value="OVERFLOW_TO_DISK"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
 	</xsd:complexType>
 	<!-- Expiration -->
 	<xsd:complexType name="expirationType">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionEvictionAttributesNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionEvictionAttributesNamespaceTest-context.xml
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
 	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
 	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
 ">
-
-	<util:properties id="evictionProperties">
-		<prop key="eviction.action">Overflow_To_Disk</prop>
-		<prop key="eviction.type">heap_percentage</prop>
-	</util:properties>
-
-	<context:property-placeholder properties-ref="evictionProperties"/>
 
 	<util:properties id="gemfireProperties">
 		<prop key="name">RegionEvictionAttributesNamespaceTest</prop>
@@ -35,11 +26,11 @@
 	</gfe:partitioned-region>
 
 	<gfe:replicated-region id="Three">
-		<gfe:eviction type="${eviction.type}" action="OVERFLOW_TO_DISK"/>
+		<gfe:eviction type="HEAP_PERCENTAGE" action="OVERFLOW_TO_DISK"/>
 	</gfe:replicated-region>
 
 	<gfe:partitioned-region id="Four">
-		<gfe:eviction type="${eviction.type}" action="OVERFLOW_TO_DISK"/>
+		<gfe:eviction type="HEAP_PERCENTAGE" action="OVERFLOW_TO_DISK"/>
 	</gfe:partitioned-region>
 
 	<gfe:replicated-region id="Five">
@@ -47,7 +38,7 @@
 	</gfe:replicated-region>
 
 	<gfe:partitioned-region id="Six" local-max-memory="512">
-		<gfe:eviction threshold="256" type="MEMORY_SIZE" action="${eviction.action}"/>
+		<gfe:eviction threshold="256" type="MEMORY_SIZE" action="OVERFLOW_TO_DISK"/>
 	</gfe:partitioned-region>
 
 </beans>


### PR DESCRIPTION
  - Refactor spring-geode-2.1.xsd such that all region types except
    for replicated region now refer to a common `evictionType` element
    definition.
  - Add enumerations to the attributes of `evictionType` element.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/SGF).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

