### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/src/test/resources/SpringServerLauncherCacheProviderIntegrationTest-context.xml
+++ b/src/test/resources/SpringServerLauncherCacheProviderIntegrationTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/autoregionlookup-cache.xml
+++ b/src/test/resources/autoregionlookup-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN"
-	"http://www.gemstone.com/dtd/cache8_0.dtd">
+	"https://www.gemstone.com/dtd/cache8_0.dtd">
 <cache>
 	<region name="NativePartitionedRegion" refid="PARTITION"/>
 

--- a/src/test/resources/cache-with-declarable.xml
+++ b/src/test/resources/cache-with-declarable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN" "http://www.gemstone.com/dtd/cache8_0.dtd">
+<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN" "https://www.gemstone.com/dtd/cache8_0.dtd">
 <cache>
   <region name="Example">
     <region-attributes data-policy="normal">

--- a/src/test/resources/cache-with-regions.xml
+++ b/src/test/resources/cache-with-regions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN"
-	"http://www.gemstone.com/dtd/cache7_0.dtd">
+	"https://www.gemstone.com/dtd/cache7_0.dtd">
 <cache>
 	<region name="NativeLocalRegion" refid="LOCAL">
 		<region-attributes cloning-enabled="false"

--- a/src/test/resources/cache-with-spring-context-bootstrap-initializer-using-base-packages.xml
+++ b/src/test/resources/cache-with-spring-context-bootstrap-initializer-using-base-packages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<region name="Users" refid="REPLICATE">

--- a/src/test/resources/cache-with-spring-context-bootstrap-initializer.xml
+++ b/src/test/resources/cache-with-spring-context-bootstrap-initializer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<region name="Users" refid="REPLICATE">

--- a/src/test/resources/clientcache-with-regions.xml
+++ b/src/test/resources/clientcache-with-regions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE client-cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN"
-	"http://www.gemstone.com/dtd/cache7_0.dtd">
+	"https://www.gemstone.com/dtd/cache7_0.dtd">
 <client-cache>
 	<region name="NativeClientRegion" refid="LOCAL">
 		<region-attributes cloning-enabled="false"/>

--- a/src/test/resources/empty-cache.xml
+++ b/src/test/resources/empty-cache.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN"
-	"http://www.gemstone.com/dtd/cache8_0.dtd">
+	"https://www.gemstone.com/dtd/cache8_0.dtd">
 <cache>
 </cache>

--- a/src/test/resources/empty-client-cache.xml
+++ b/src/test/resources/empty-client-cache.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE client-cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN"
-	"http://www.gemstone.com/dtd/cache8_0.dtd">
+	"https://www.gemstone.com/dtd/cache8_0.dtd">
 <client-cache>
 </client-cache>

--- a/src/test/resources/gemfire-cache.xml
+++ b/src/test/resources/gemfire-cache.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 5.7//EN" "http://www.gemstone.com/dtd/cache5_7.dtd">
+<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 5.7//EN" "https://www.gemstone.com/dtd/cache5_7.dtd">
 <cache lock-lease="120" lock-timeout="60" search-timeout="300">
   <region-attributes id="attTemplate" scope="local" data-policy="normal" initial-capacity="16" load-factor="0.75" concurrency-level="16" statistics-enabled="true">
     <key-constraint>java.lang.String</key-constraint>

--- a/src/test/resources/gemfire-client-cache.xml
+++ b/src/test/resources/gemfire-client-cache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
   <!DOCTYPE client-cache PUBLIC
     "-//GemStone Systems, Inc.//GemFire Declarative Caching 6.5//EN"
-    "http://www.gemstone.com/dtd/cache6_5.dtd">
+    "https://www.gemstone.com/dtd/cache6_5.dtd">
 
 <client-cache>      
    <pool name="DEFAULT">

--- a/src/test/resources/gemfire-datasource-integration-test-cache.xml
+++ b/src/test/resources/gemfire-datasource-integration-test-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN"
-	"http://www.gemstone.com/dtd/cache8_0.dtd">
+	"https://www.gemstone.com/dtd/cache8_0.dtd">
 <cache>
 	<cache-server hostname-for-clients="localhost" port="42082"/>
 	<region name="ServerRegion" refid="PARTITION"/>

--- a/src/test/resources/lazy-wiring-declarable-support-function-cache.xml
+++ b/src/test/resources/lazy-wiring-declarable-support-function-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 8.0//EN"
-	"http://www.gemstone.com/dtd/cache8_0.dtd">
+	"https://www.gemstone.com/dtd/cache8_0.dtd">
 <cache>
 	<function-service>
 		<function>

--- a/src/test/resources/lookup-region-mutation-cache.xml
+++ b/src/test/resources/lookup-region-mutation-cache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<region name="Example">

--- a/src/test/resources/non-cluster-config-cache.xml
+++ b/src/test/resources/non-cluster-config-cache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <cache xmlns="http://geode.apache.org/schema/cache"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
 	   version="1.0">
 
 	<region name="NativeLocalRegion" refid="LOCAL">

--- a/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupIntegrationTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupWithAutowiringIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupWithAutowiringIntegrationTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.AutoRegionLookupWithAutowiringIntegrationTests$TestComponent"

--- a/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupWithComponentScanningIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/AutoRegionLookupWithComponentScanningIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<!-- TODO refactor this configuration... yikes! -->

--- a/src/test/resources/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/allowRegionBeanDefinitionOverridesTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/allowRegionBeanDefinitionOverridesTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/basic-cache.xml
+++ b/src/test/resources/org/springframework/data/gemfire/basic-cache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	   default-lazy-init="true">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/basic-region.xml
+++ b/src/test/resources/org/springframework/data/gemfire/basic-region.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/basic-tx-config.xml
+++ b/src/test/resources/org/springframework/data/gemfire/basic-tx-config.xml
@@ -4,8 +4,8 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cache-server-with-subscription-disk-store.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cache-server-with-subscription-disk-store.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cache/CachingWithGemFireIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cache/CachingWithGemFireIntegrationTest-context.xml
@@ -7,11 +7,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cache/cache-manager-client-cache.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cache/cache-manager-client-cache.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cacheAutoReconnectDisabledIntegrationTests.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cacheAutoReconnectDisabledIntegrationTests.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cacheAutoReconnectEnabledIntegrationTests.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cacheAutoReconnectEnabledIntegrationTests.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/cacheUsingClusterConfigurationIntegrationTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cacheUsingClusterConfigurationIntegrationTest.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/cacheUsingLocalConfigurationIntegrationTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/cacheUsingLocalConfigurationIntegrationTest.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheIndexingTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheIndexingTest-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<gfe:pool id="serverConnectionPool">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheIndexingTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheIndexingTest-server-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCachePoolTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCachePoolTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCachePoolTests-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCachePoolTests-server-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheSecurityTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheSecurityTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="clientProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheSecurityTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheSecurityTest-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="serverProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableLocatorsTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableLocatorsTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="client.properties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableLocatorsTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableLocatorsTest-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="server.properties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableServersTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableServersTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="clientProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableServersTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientCacheVariableServersTest-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="server.properties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientRegionWithCacheLoaderWriterTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientRegionWithCacheLoaderWriterTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests-context.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/DurableClientCacheIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/DurableClientCacheIntegrationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="clientProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/DurableClientCacheIntegrationTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/DurableClientCacheIntegrationTest-server-context.xml
@@ -7,10 +7,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="serverProperties">

--- a/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTest-server-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:repo="http://www.springframework.org/schema/data/repository"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
 " default-lazy-init="true">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder/>
 

--- a/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTest-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="client.properties">

--- a/src/test/resources/org/springframework/data/gemfire/client/SpELExpressionConfiguredPoolsIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/client/SpELExpressionConfiguredPoolsIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="clientProperties">

--- a/src/test/resources/org/springframework/data/gemfire/colocated-region.xml
+++ b/src/test/resources/org/springframework/data/gemfire/colocated-region.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/complex-subregion.xml
+++ b/src/test/resources/org/springframework/data/gemfire/complex-subregion.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/support/LuceneIndexRegionBeanFactoryPostProcessorIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/support/LuceneIndexRegionBeanFactoryPostProcessorIntegrationTests-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<gfe:cache/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/AsyncEventQueueNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/AsyncEventQueueNamespaceTest-context.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/ClientCacheNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/ClientCacheNamespaceTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/ContinuousQueryListenerContainerNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/ContinuousQueryListenerContainerNamespaceTest-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/GatewayReceiverNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/GatewayReceiverNamespaceTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/InvalidDataPolicyPersistentAttributeSettingsBeansNamespaceTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/InvalidDataPolicyPersistentAttributeSettingsBeansNamespaceTest.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/InvalidRegionExpirationAttributesNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/InvalidRegionExpirationAttributesNamespaceTest-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/LocalRegionWithEvictionPolicyActionNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/LocalRegionWithEvictionPolicyActionNamespaceTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/LuceneNamespaceUnitTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/LuceneNamespaceUnitTests-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/MultipleCacheTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/MultipleCacheTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionDefinitionUsingBeansNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionDefinitionUsingBeansNamespaceTest-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionEvictionAttributesNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionEvictionAttributesNamespaceTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="evictionProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionExpirationAttributesNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionExpirationAttributesNamespaceTest-context.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="expirationProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionSubscriptionAttributesNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionSubscriptionAttributesNamespaceTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="subscriptionProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionWithSubRegionBeanDefinitionHashCodeTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionWithSubRegionBeanDefinitionHashCodeTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/RegionsWithDiskStoreAndPersistenceEvictionSettingsTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateClientRegionNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateClientRegionNamespaceTest-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/TemplatePersistentPartitionRegionNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/TemplatePersistentPartitionRegionNamespaceTest-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
        ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateRegionDefinitionOrderErrorNamespaceTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateRegionDefinitionOrderErrorNamespaceTest-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<gfe:cache/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateRegionsNamespaceTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/TemplateRegionsNamespaceTests-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/cache-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/cache-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
 default-lazy-init="true">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/cache-using-pdx-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/cache-using-pdx-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/client-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/client-ns.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="placeholderProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/client-region-using-datapolicy-and-shortcut.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/client-region-using-datapolicy-and-shortcut.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/diskstore-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/diskstore-ns.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/dynamic-region-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/dynamic-region-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	    http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	    http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/function-service-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/function-service-ns.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 " default-lazy-init="true">
 
     <gfe:function-service>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/gateway-v7-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/gateway-v7-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/gateway-v8-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/gateway-v8-ns.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/index-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/index-ns.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="indexConfiguration">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/jndi-binding-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/jndi-binding-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/jndi-binding-with-property-placeholders-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/jndi-binding-with-property-placeholders-ns.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/local-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/local-ns.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/membership-attributes-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/membership-attributes-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/partitioned-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/partitioned-ns.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/pool-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/pool-ns.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder location="classpath:port.properties"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/replicated-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/replicated-ns.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/server-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/server-ns.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="cacheServerConfiguration">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-with-inconsistent-datapolicy-persistent-settings.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-with-inconsistent-datapolicy-persistent-settings.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-with-invalid-datapolicy.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/subregion-with-invalid-datapolicy.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/subregionsubelement-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/subregionsubelement-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/subscription-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/subscription-ns.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/support/PoolAlreadyExistsIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/support/PoolAlreadyExistsIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/tx-listeners-and-writers.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/tx-listeners-and-writers.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 " default-lazy-init="true">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/config/xml/tx-ns.xml
+++ b/src/test/resources/org/springframework/data/gemfire/config/xml/tx-ns.xml
@@ -3,9 +3,9 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/diskstore-using-propertyplaceholders-config.xml
+++ b/src/test/resources/org/springframework/data/gemfire/diskstore-using-propertyplaceholders-config.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:map id="diskStoreConfiguration" key-type="java.lang.String">

--- a/src/test/resources/org/springframework/data/gemfire/enableClientRegionLookupsTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/enableClientRegionLookupsTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/enableRegionLookupsTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/enableRegionLookupsTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/expiration/AnnotationBasedExpirationConfigurationIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/expiration/AnnotationBasedExpirationConfigurationIntegrationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<util:properties id="expirationProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest-server-context.xml
@@ -4,10 +4,10 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/function/ExceptionThrowingFunctionExecutionIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/ExceptionThrowingFunctionExecutionIntegrationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/ExceptionThrowingFunctionExecutionIntegrationTest-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/ExceptionThrowingFunctionExecutionIntegrationTest-server-context.xml
@@ -4,10 +4,10 @@
 	   xmlns:gfe="http://www.springframework.org/schema/geode"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="serverProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/GemfireFunctionProxyFactoryBeanTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/GemfireFunctionProxyFactoryBeanTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/config/AnnotationDrivenFunctionsTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/config/AnnotationDrivenFunctionsTest-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:gfe="http://www.springframework.org/schema/geode"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="org.springframework.data.gemfire.function.config" resource-pattern="**/AnnotationDrivenFunctionsTest*.class"/>
 

--- a/src/test/resources/org/springframework/data/gemfire/function/config/FunctionExecutionCacheClientTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/config/FunctionExecutionCacheClientTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/config/FunctionExecutionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/config/FunctionExecutionIntegrationTests-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/config/FunctionsWithClientCacheTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/config/FunctionsWithClientCacheTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:gfe-data="http://www.springframework.org/schema/data/gemfire"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/config/XmlConfiguredFunctionExecutionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/config/XmlConfiguredFunctionExecutionIntegrationTests-context.xml
@@ -4,10 +4,10 @@
 	   xmlns:gfe-data="http://www.springframework.org/schema/data/gemfire"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/invalid-region-shortcut-with-persistent-attribute.xml
+++ b/src/test/resources/org/springframework/data/gemfire/invalid-region-shortcut-with-persistent-attribute.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/invalid-use-of-region-datapolicy-and-shortcut.xml
+++ b/src/test/resources/org/springframework/data/gemfire/invalid-use-of-region-datapolicy-and-shortcut.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/listener/adapter/ContainerXmlSetupIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/listener/adapter/ContainerXmlSetupIntegrationTests-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-	   	http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-	   	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+	   	http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+	   	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/locatorContext.xml
+++ b/src/test/resources/org/springframework/data/gemfire/locatorContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "https://www.springframework.org/dtd/spring-beans.dtd">
 
 <!--
 	Context used for testing GemfireBFLocator - usually, one doesn't have to declare the them inside

--- a/src/test/resources/org/springframework/data/gemfire/lookupSubRegion.xml
+++ b/src/test/resources/org/springframework/data/gemfire/lookupSubRegion.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noClientRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noClientRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noClientSubRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noClientSubRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noDuplicateRegionDefinitionsTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noDuplicateRegionDefinitionsTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noLocalRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noLocalRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noPartitionRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noPartitionRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noReplicateRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noReplicateRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/noSubRegionLookupTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/noSubRegionLookupTest.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/pdxdiskstore-config.xml
+++ b/src/test/resources/org/springframework/data/gemfire/pdxdiskstore-config.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/region-datapolicy-shortcuts.xml
+++ b/src/test/resources/org/springframework/data/gemfire/region-datapolicy-shortcuts.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
   ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:repo="http://www.springframework.org/schema/data/repository"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests-server-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests-server-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<context:property-placeholder/>

--- a/src/test/resources/org/springframework/data/gemfire/repository/config/partitioned-region-repo-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/config/partitioned-region-repo-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/config/repo-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/config/repo-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+    	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/AlgorithmRepositoryTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/AlgorithmRepositoryTest-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/AnimalRepositoryTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/AnimalRepositoryTest-context.xml
@@ -6,11 +6,11 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/UsingQueryAnnotationExtensionsInUserRepositoryIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/UsingQueryAnnotationExtensionsInUserRepositoryIntegrationTest-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/repositoryQueriesWithJoins.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/repositoryQueriesWithJoins.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		    http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		    http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/subregionRepository.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/subregionRepository.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/sample/userRepositoryQueriesIntegrationTest.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/sample/userRepositoryQueriesIntegrationTest.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/support/PersonRepositoryIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/support/PersonRepositoryIntegrationTests-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/data/repository http://www.springframework.org/schema/data/repository/spring-repository.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/data/repository https://www.springframework.org/schema/data/repository/spring-repository.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/repository/support/SimpleGemfireRepositoryTransactionalIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/repository/support/SimpleGemfireRepositoryTransactionalIntegrationTest-context.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/serialization/json/JSONRegionAdviceIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/serialization/json/JSONRegionAdviceIntegrationTests-context.xml
@@ -6,10 +6,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/serialization/simple-config.xml
+++ b/src/test/resources/org/springframework/data/gemfire/serialization/simple-config.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config/>
 

--- a/src/test/resources/org/springframework/data/gemfire/snapshot/SnapshotApplicationEventTriggeredImportsExportsIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/snapshot/SnapshotApplicationEventTriggeredImportsExportsIntegrationTest-context.xml
@@ -8,12 +8,12 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-        http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+        http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/snapshot/SnapshotServiceImportExportIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/snapshot/SnapshotServiceImportExportIntegrationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/support/GemfireBeanFactoryLocatorIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/GemfireBeanFactoryLocatorIntegrationTests-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/gemfire https://www.springframework.org/schema/gemfire/spring-gemfire.xsd
 ">
 
 	<bean class="org.springframework.data.gemfire.test.GemfireTestBeanPostProcessor"/>

--- a/src/test/resources/org/springframework/data/gemfire/support/GemfirePersistenceExceptionTranslationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/GemfirePersistenceExceptionTranslationTest-context.xml
@@ -5,10 +5,10 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/support/LazyWiringDeclarableSupportFunctionBasedIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/LazyWiringDeclarableSupportFunctionBasedIntegrationTests-context.xml
@@ -6,11 +6,11 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/data/gemfire http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/data/gemfire https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="helloProperties">

--- a/src/test/resources/org/springframework/data/gemfire/support/LazyWiringDeclarableSupportIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/LazyWiringDeclarableSupportIntegrationTests-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 ">
 
 	<bean id="userDataSource" class="org.springframework.data.gemfire.support.LazyWiringDeclarableSupportIntegrationTests$TestDataSource"/>

--- a/src/test/resources/org/springframework/data/gemfire/support/WiringDeclarableSupportIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/WiringDeclarableSupportIntegrationTests-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   	http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   	http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-dao-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-dao-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
 ">
 
 	<context:annotation-config/>

--- a/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-gemfire-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-gemfire-context.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-services-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/support/sample/initializer-services-context.xml
@@ -3,8 +3,8 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
 ">
 
 	<context:annotation-config/>

--- a/src/test/resources/org/springframework/data/gemfire/wan/CachePartitionRegionWithConcurrentParallelAsyncEventQueueAndGatewaySenderIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/wan/CachePartitionRegionWithConcurrentParallelAsyncEventQueueAndGatewaySenderIntegrationTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/wan/ManualGatewayReceiverStartIntegrationTest-context.xml
+++ b/src/test/resources/org/springframework/data/gemfire/wan/ManualGatewayReceiverStartIntegrationTest-context.xml
@@ -4,9 +4,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/org/springframework/data/gemfire/wan/asyncEventQueueWithListener.xml
+++ b/src/test/resources/org/springframework/data/gemfire/wan/asyncEventQueueWithListener.xml
@@ -5,9 +5,9 @@
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-	   	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/geode http://www.springframework.org/schema/geode/spring-geode.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/geode https://www.springframework.org/schema/geode/spring-geode.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
 ">
 
 	<util:properties id="gemfireProperties">

--- a/src/test/resources/subregion-cache.xml
+++ b/src/test/resources/subregion-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC  "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN"
-	"http://www.gemstone.com/dtd/cache7_0.dtd">
+	"https://www.gemstone.com/dtd/cache7_0.dtd">
 <cache>
 	<region name="Parent" refid="REPLICATE">
 		<region name="Child" refid="REPLICATE">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.gemstone.com/dtd/cache5_7.dtd (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.gemstone.com/dtd/cache5_7.dtd ([https](https://www.gemstone.com/dtd/cache5_7.dtd) result ConnectTimeoutException).
* http://www.gemstone.com/dtd/cache6_5.dtd (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.gemstone.com/dtd/cache6_5.dtd ([https](https://www.gemstone.com/dtd/cache6_5.dtd) result ConnectTimeoutException).
* http://www.gemstone.com/dtd/cache7_0.dtd (ConnectTimeoutException) with 3 occurrences migrated to:  
  https://www.gemstone.com/dtd/cache7_0.dtd ([https](https://www.gemstone.com/dtd/cache7_0.dtd) result ConnectTimeoutException).
* http://www.gemstone.com/dtd/cache8_0.dtd (ConnectTimeoutException) with 6 occurrences migrated to:  
  https://www.gemstone.com/dtd/cache8_0.dtd ([https](https://www.gemstone.com/dtd/cache8_0.dtd) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://geode.apache.org/schema/cache/cache-1.0.xsd with 4 occurrences migrated to:  
  https://geode.apache.org/schema/cache/cache-1.0.xsd ([https](https://geode.apache.org/schema/cache/cache-1.0.xsd) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.springframework.org/dtd/spring-beans.dtd with 1 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans.dtd ([https](https://www.springframework.org/dtd/spring-beans.dtd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 141 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/cache/spring-cache.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 52 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd with 21 occurrences migrated to:  
  https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd ([https](https://www.springframework.org/schema/data/gemfire/spring-data-gemfire.xsd) result 200).
* http://www.springframework.org/schema/data/repository/spring-repository.xsd with 11 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* http://www.springframework.org/schema/gemfire/spring-gemfire.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/gemfire/spring-gemfire.xsd ([https](https://www.springframework.org/schema/gemfire/spring-gemfire.xsd) result 200).
* http://www.springframework.org/schema/geode/spring-geode.xsd with 132 occurrences migrated to:  
  https://www.springframework.org/schema/geode/spring-geode.xsd ([https](https://www.springframework.org/schema/geode/spring-geode.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 125 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://geode.apache.org/schema/cache with 8 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 282 occurrences
* http://www.springframework.org/schema/c with 3 occurrences
* http://www.springframework.org/schema/cache with 2 occurrences
* http://www.springframework.org/schema/context with 104 occurrences
* http://www.springframework.org/schema/data/gemfire with 42 occurrences
* http://www.springframework.org/schema/data/repository with 22 occurrences
* http://www.springframework.org/schema/gemfire with 2 occurrences
* http://www.springframework.org/schema/geode with 264 occurrences
* http://www.springframework.org/schema/p with 23 occurrences
* http://www.springframework.org/schema/task with 6 occurrences
* http://www.springframework.org/schema/util with 250 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 146 occurrences