### PR TITLE
DATAGEODE-209 - Prepare for parallel test execution

### DIFF
--- a/src/test/java/org/springframework/data/gemfire/GemfireTemplateQueriesOnGroupedPooledClientCacheRegionsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/GemfireTemplateQueriesOnGroupedPooledClientCacheRegionsIntegrationTests.java
@@ -33,7 +33,9 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.Pool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -75,6 +77,7 @@ import lombok.RequiredArgsConstructor;
  * with the data of interest are targeted.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.junit.runner.RunWith
  * @see org.springframework.data.gemfire.GemfireTemplate
@@ -101,11 +104,14 @@ public class GemfireTemplateQueriesOnGroupedPooledClientCacheRegionsIntegrationT
 	@Qualifier("dogsTemplate")
 	private GemfireTemplate dogsTemplate;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void setupGemFireCluster() throws Exception {
-		serverOne = ProcessExecutor.launch(createDirectory("serverOne"), GemFireCacheServerOneConfiguration.class);
+		serverOne = ProcessExecutor.launch(tempDir.newFolder("serverOne"), GemFireCacheServerOneConfiguration.class);
 		waitForServerToStart("localhost", 41414);
-		serverTwo = ProcessExecutor.launch(createDirectory("serverTwo"), GemFireCacheServerTwoConfiguration.class);
+		serverTwo = ProcessExecutor.launch(tempDir.newFolder("serverTwo"), GemFireCacheServerTwoConfiguration.class);
 		waitForServerToStart("localhost", 42424);
 	}
 

--- a/src/test/java/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/client/ClientSubRegionIntegrationTests.java
@@ -24,7 +24,9 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.gemfire.GemfireTemplate;
@@ -38,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Integration test testing {@link Region sub-Region} functionality from a GemFire cache client.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.junit.runner.RunWith
  * @see org.springframework.data.gemfire.test.support.ClientServerIntegrationTestsSupport
@@ -67,11 +70,14 @@ public class ClientSubRegionIntegrationTests extends ClientServerIntegrationTest
 	@Resource(name = "/Parent/Child")
 	private Region child;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), ServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort),
 			getServerContextXmlFileLocation(ClientSubRegionIntegrationTests.class));
 

--- a/src/test/java/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/client/GemFireDataSourceIntegrationTests.java
@@ -24,7 +24,9 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.Pool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -42,6 +44,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  *
  * @author David Turanski
  * @author John Blum
+ * @author Jens Deppe
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -53,6 +56,9 @@ public class GemFireDataSourceIntegrationTests extends ClientServerIntegrationTe
 
 	@Autowired
 	private ApplicationContext applicationContext;
+
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
 
 	@BeforeClass
 	public static void setGemFireLogLevel() {
@@ -69,7 +75,7 @@ public class GemFireDataSourceIntegrationTests extends ClientServerIntegrationTe
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), ServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort),
 			getServerContextXmlFileLocation(GemFireDataSourceIntegrationTests.class));
 

--- a/src/test/java/org/springframework/data/gemfire/client/GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTest.java
+++ b/src/test/java/org/springframework/data/gemfire/client/GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTest.java
@@ -31,7 +31,9 @@ import org.apache.geode.distributed.ServerLauncher;
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -40,7 +42,6 @@ import org.springframework.data.gemfire.GemfireUtils;
 import org.springframework.data.gemfire.fork.GemFireBasedServerProcess;
 import org.springframework.data.gemfire.process.ProcessExecutor;
 import org.springframework.data.gemfire.process.ProcessWrapper;
-import org.springframework.data.gemfire.test.support.FileSystemUtils;
 import org.springframework.data.gemfire.test.support.ThreadUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -56,6 +57,7 @@ import org.springframework.util.StringUtils;
  * in the Spring ApplicationContext correctly.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.springframework.data.gemfire.client.GemfireDataSourcePostProcessor
  * @since 1.7.0
  */
@@ -84,6 +86,9 @@ public class GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTe
 	@Resource(name = "AnotherServerRegion")
 	private Region anotherServerRegion;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws IOException {
 
@@ -91,7 +96,7 @@ public class GemFireDataSourceUsingNonSpringConfiguredGemFireServerIntegrationTe
 
 		String serverName = "GemFireDataSourceGemFireBasedServer";
 
-		File serverWorkingDirectory = new File(FileSystemUtils.WORKING_DIRECTORY, serverName.toLowerCase());
+		File serverWorkingDirectory = tempDir.getRoot();
 
 		Assert.isTrue(serverWorkingDirectory.isDirectory() || serverWorkingDirectory.mkdirs(),
 			String.format("Server working directory [%s] does not exist and could not be created", serverWorkingDirectory));

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/AutoConfiguredAuthenticationConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/AutoConfiguredAuthenticationConfigurationIntegrationTests.java
@@ -31,7 +31,9 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +49,7 @@ import org.springframework.mock.env.MockPropertySource;
  * The AutoConfiguredAuthenticationConfigurationIntegrationTests class...
  *
  * @author John Blum
+ * @author Jens Deppe
  * @since 1.0.0
  */
 @SuppressWarnings("unused")
@@ -58,10 +61,13 @@ public class AutoConfiguredAuthenticationConfigurationIntegrationTests extends C
 
 	private ConfigurableApplicationContext applicationContext;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void setupGemFireServer() throws Exception {
 
-		gemfireServerProcess = run(TestGemFireServerConfiguration.class, String.format("-Dgemfire.name=%1$s",
+		gemfireServerProcess = run(tempDir.getRoot(), TestGemFireServerConfiguration.class, String.format("-Dgemfire.name=%1$s",
 			asApplicationName(AutoConfiguredAuthenticationConfigurationIntegrationTests.class)));
 
 		Optional.ofNullable(gemfireServerProcess)

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/ClientServerCacheApplicationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/ClientServerCacheApplicationIntegrationTests.java
@@ -30,7 +30,9 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +49,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * or Apache Geode client/server topology
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.springframework.data.gemfire.config.annotation.CacheServerApplication
  * @see org.springframework.data.gemfire.config.annotation.ClientCacheApplication
@@ -65,10 +68,13 @@ public class ClientServerCacheApplicationIntegrationTests extends ClientServerIn
 
 	private static ProcessWrapper gemfireServerProcess;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void setupGemFireServer() throws Exception {
 
-		gemfireServerProcess = run(ServerTestConfiguration.class, String.format("-Dgemfire.name=%1$s",
+		gemfireServerProcess = run(tempDir.getRoot(), ServerTestConfiguration.class, String.format("-Dgemfire.name=%1$s",
 			asApplicationName(ClientServerCacheApplicationIntegrationTests.class)));
 
 		waitForServerToStart("localhost", PORT);

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableClusterConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableClusterConfigurationIntegrationTests.java
@@ -26,7 +26,9 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,6 +55,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * and {@link ClusterConfigurationConfiguration} class.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.apache.geode.cache.GemFireCache
  * @see org.apache.geode.cache.client.ClientCache
@@ -85,12 +88,15 @@ public class EnableClusterConfigurationIntegrationTests extends ClientServerInte
 
 	private GemfireAdminOperations adminOperations;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerTestConfiguration.class,
+		gemfireServer = run(tempDir.getRoot(), ServerTestConfiguration.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart("localhost", availablePort);

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableClusterDefinedRegionsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableClusterDefinedRegionsIntegrationTests.java
@@ -27,7 +27,9 @@ import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.Region;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -47,6 +49,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Integration tests for {@link EnableClusterDefinedRegions} and {@link ClusterDefinedRegionsConfiguration}.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.apache.geode.cache.GemFireCache
  * @see org.apache.geode.cache.Region
@@ -67,12 +70,15 @@ public class EnableClusterDefinedRegionsIntegrationTests extends ClientServerInt
 
 	private static ProcessWrapper gemfireServer;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerTestConfiguration.class,
+		gemfireServer = run(tempDir.getRoot(), ServerTestConfiguration.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart("localhost", availablePort);

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableContinuousQueriesConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableContinuousQueriesConfigurationIntegrationTests.java
@@ -39,7 +39,9 @@ import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -65,6 +67,7 @@ import lombok.RequiredArgsConstructor;
  * and {@link ContinuousQueryListenerContainer}.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.apache.geode.cache.GemFireCache
  * @see org.apache.geode.cache.Region
@@ -89,12 +92,15 @@ public class EnableContinuousQueriesConfigurationIntegrationTests extends Client
 
 	private static ProcessWrapper gemfireServer;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(GemFireServerConfiguration.class,
+		gemfireServer = run(tempDir.getRoot(), GemFireServerConfiguration.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart("localhost", availablePort);

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableContinuousQueriesWithClusterConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableContinuousQueriesWithClusterConfigurationIntegrationTests.java
@@ -27,7 +27,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.geode.cache.query.CqEvent;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +52,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Integration tests testing the combination of {@link EnableContinuousQueries} with {@link EnableClusterConfiguration}.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.apache.geode.cache.query.CqEvent
  * @see org.springframework.data.gemfire.config.annotation.EnableClusterConfiguration
@@ -70,12 +73,15 @@ public class EnableContinuousQueriesWithClusterConfigurationIntegrationTests
 
 	private static ProcessWrapper gemfireServer;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(EnableContinuousQueriesWithClusterConfigurationIntegrationTests.GemFireServerConfiguration.class,
+		gemfireServer = run(tempDir.getRoot(), EnableContinuousQueriesWithClusterConfigurationIntegrationTests.GemFireServerConfiguration.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart("localhost", availablePort);

--- a/src/test/java/org/springframework/data/gemfire/config/annotation/EnableSslConfigurationIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/config/annotation/EnableSslConfigurationIntegrationTests.java
@@ -21,7 +21,9 @@ import javax.annotation.Resource;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.CacheLoader;
@@ -45,6 +47,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Integration tests for {@link EnableSsl} and {@link SslConfiguration}.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.springframework.data.gemfire.config.annotation.ClientCacheApplication
  * @see org.springframework.data.gemfire.config.annotation.EnableSsl
@@ -63,6 +66,9 @@ public class EnableSslConfigurationIntegrationTests extends ClientServerIntegrat
 	@Resource(name = "Echo")
 	private Region<String, String> echo;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void setupGemFireServer() throws Exception {
 
@@ -70,7 +76,7 @@ public class EnableSslConfigurationIntegrationTests extends ClientServerIntegrat
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerTestConfiguration.class,
+		gemfireServer = run(tempDir.getRoot(), ServerTestConfiguration.class,
 			String.format("-Dgemfire.name=%s", asApplicationName(EnableSslConfigurationIntegrationTests.class)),
 			String.format("-Djavax.net.ssl.keyStore=%s", System.getProperty("javax.net.ssl.keyStore")),
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));

--- a/src/test/java/org/springframework/data/gemfire/config/xml/ContinuousQueryListenerContainerNamespaceTest.java
+++ b/src/test/java/org/springframework/data/gemfire/config/xml/ContinuousQueryListenerContainerNamespaceTest.java
@@ -34,7 +34,9 @@ import org.apache.geode.cache.query.CqListener;
 import org.apache.geode.cache.query.CqQuery;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.gemfire.TestUtils;
@@ -54,6 +56,7 @@ import org.springframework.util.ErrorHandler;
  * using the SDG XML namespace.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.junit.runner.RunWith
  * @see org.apache.geode.cache.client.ClientCache
@@ -71,12 +74,15 @@ public class ContinuousQueryListenerContainerNamespaceTest extends ClientServerI
 
 	private static ProcessWrapper gemfireServer;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(CqCacheServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), CqCacheServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart(DEFAULT_HOSTNAME, availablePort);

--- a/src/test/java/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest.java
+++ b/src/test/java/org/springframework/data/gemfire/function/ClientCacheFunctionExecutionWithPdxIntegrationTest.java
@@ -34,7 +34,9 @@ import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.pdx.internal.PdxInstanceEnum;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -56,6 +58,7 @@ import org.springframework.util.ObjectUtils;
  * when PDX is configured and read-serialized is set to true.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see org.junit.Test
  * @see org.junit.runner.RunWith
  * @see SpringContainerProcess
@@ -82,12 +85,15 @@ public class ClientCacheFunctionExecutionWithPdxIntegrationTest extends ClientSe
 	@Autowired
 	private ApplicationDomainFunctionExecutions functionExecutions;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), ServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort),
 			getServerContextXmlFileLocation(ClientCacheFunctionExecutionWithPdxIntegrationTest.class));
 

--- a/src/test/java/org/springframework/data/gemfire/function/execution/FunctionExecutionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/function/execution/FunctionExecutionIntegrationTests.java
@@ -26,7 +26,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.data.gemfire.fork.FunctionCacheServerProcess;
 import org.springframework.data.gemfire.process.ProcessWrapper;
 import org.springframework.data.gemfire.test.support.ClientServerIntegrationTestsSupport;
@@ -34,6 +36,7 @@ import org.springframework.data.gemfire.test.support.ClientServerIntegrationTest
 /**
  * @author David Turanski
  * @author John Blum
+ * @author Jens Deppe
  */
 public class FunctionExecutionIntegrationTests extends ClientServerIntegrationTestsSupport {
 
@@ -47,12 +50,15 @@ public class FunctionExecutionIntegrationTests extends ClientServerIntegrationTe
 
 	private Region<String, String> gemfireRegion = null;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		availablePort = findAvailablePort();
 
-		gemfireServer = run(FunctionCacheServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), FunctionCacheServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart(DEFAULT_HOSTNAME, availablePort);

--- a/src/test/java/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/function/execution/FunctionIntegrationTests.java
@@ -29,7 +29,9 @@ import org.apache.geode.cache.Region;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.data.gemfire.fork.ServerProcess;
 import org.springframework.data.gemfire.function.annotation.GemfireFunction;
@@ -43,6 +45,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * @author David Turanski
  * @author John Blum
+ * @author Jens Deppe
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -54,11 +57,14 @@ public class FunctionIntegrationTests extends ClientServerIntegrationTestsSuppor
 	@Resource(name = "test-region")
 	private Region<String, Integer> region;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), ServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort),
 			getServerContextXmlFileLocation(FunctionIntegrationTests.class));
 

--- a/src/test/java/org/springframework/data/gemfire/function/execution/GemfireFunctionTemplateIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/function/execution/GemfireFunctionTemplateIntegrationTests.java
@@ -25,7 +25,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.data.gemfire.GemfireUtils;
 import org.springframework.data.gemfire.fork.FunctionCacheServerProcess;
 import org.springframework.data.gemfire.process.ProcessWrapper;
@@ -33,6 +35,7 @@ import org.springframework.data.gemfire.test.support.ClientServerIntegrationTest
 
 /**
  * @author David Turanski
+ * @author Jens Deppe
  */
 public class GemfireFunctionTemplateIntegrationTests extends ClientServerIntegrationTestsSupport {
 
@@ -46,12 +49,15 @@ public class GemfireFunctionTemplateIntegrationTests extends ClientServerIntegra
 
 	private Region<String, String> gemfireRegion = null;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		availablePort = findAvailablePort();
 
-		gemfireServer = run(FunctionCacheServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), FunctionCacheServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart(DEFAULT_HOSTNAME, availablePort);

--- a/src/test/java/org/springframework/data/gemfire/listener/ListenerContainerIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/listener/ListenerContainerIntegrationTests.java
@@ -31,7 +31,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.data.gemfire.fork.CqCacheServerProcess;
 import org.springframework.data.gemfire.listener.adapter.ContinuousQueryListenerAdapter;
 import org.springframework.data.gemfire.process.ProcessWrapper;
@@ -39,6 +41,7 @@ import org.springframework.data.gemfire.test.support.ClientServerIntegrationTest
 
 /**
  * @author Costin Leau
+ * @author Jens Deppe
  */
 public class ListenerContainerIntegrationTests extends ClientServerIntegrationTestsSupport {
 
@@ -58,11 +61,14 @@ public class ListenerContainerIntegrationTests extends ClientServerIntegrationTe
 
 	private final List<CqEvent> cqEvents = new CopyOnWriteArrayList<>();
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 		availablePort = findAvailablePort();
 
-		gemfireServer = run(CqCacheServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), CqCacheServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart(DEFAULT_HOSTNAME, availablePort);

--- a/src/test/java/org/springframework/data/gemfire/listener/adapter/ContainerXmlSetupIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/listener/adapter/ContainerXmlSetupIntegrationTests.java
@@ -23,7 +23,9 @@ import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.query.CqQuery;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -37,6 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * @author Costin Leau
  * @author John Blum
+ * @author Jens Deppe
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -46,12 +49,15 @@ public class ContainerXmlSetupIntegrationTests extends ClientServerIntegrationTe
 
 	private static ProcessWrapper gemfireServer;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(CqCacheServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), CqCacheServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort));
 
 		waitForServerToStart(DEFAULT_HOSTNAME, availablePort);

--- a/src/test/java/org/springframework/data/gemfire/process/ProcessExecutor.java
+++ b/src/test/java/org/springframework/data/gemfire/process/ProcessExecutor.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * The {@link ProcessExecutor} class is a utility class for launching and running Java processes.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see java.io.File
  * @see java.lang.Process
  * @see java.lang.ProcessBuilder
@@ -116,7 +117,9 @@ public abstract class ProcessExecutor {
 	}
 
 	protected static boolean isJvmOption(String option) {
-		return StringUtils.hasText(option) && (option.startsWith("-D") || option.startsWith("-X"));
+		return StringUtils.hasText(option) && (option.startsWith("-D")
+			|| option.startsWith("-X")
+			|| option.startsWith("-agentlib"));
 	}
 
 	protected static File validateDirectory(File workingDirectory) {

--- a/src/test/java/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/gemfire/repository/config/RepositoryClientRegionIntegrationTests.java
@@ -16,7 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.gemfire.fork.ServerProcess;
@@ -29,6 +31,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * @author David Turanski
  * @author John Blum
+ * @author Jens Deppe
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -40,6 +43,9 @@ public class RepositoryClientRegionIntegrationTests extends ClientServerIntegrat
 	@Autowired
 	private PersonRepository repository;
 
+	@ClassRule
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
 	@BeforeClass
 	public static void startGemFireServer() throws Exception {
 
@@ -47,7 +53,7 @@ public class RepositoryClientRegionIntegrationTests extends ClientServerIntegrat
 
 		int availablePort = findAvailablePort();
 
-		gemfireServer = run(ServerProcess.class,
+		gemfireServer = run(tempDir.getRoot(), ServerProcess.class,
 			String.format("-D%s=%d", GEMFIRE_CACHE_SERVER_PORT_PROPERTY, availablePort),
 			getServerContextXmlFileLocation(RepositoryClientRegionIntegrationTests.class));
 

--- a/src/test/java/org/springframework/data/gemfire/test/support/ClientServerIntegrationTestsSupport.java
+++ b/src/test/java/org/springframework/data/gemfire/test/support/ClientServerIntegrationTestsSupport.java
@@ -41,6 +41,7 @@ import org.springframework.data.gemfire.util.CollectionUtils;
  * to support the implementation of GemFire client/server tests.
  *
  * @author John Blum
+ * @author Jens Deppe
  * @see java.io.File
  * @see java.net.ServerSocket
  * @see java.net.Socket
@@ -165,16 +166,8 @@ public class ClientServerIntegrationTestsSupport {
 			String.format("%s", CollectionUtils.toString(System.getProperties())));
 	}
 
-	protected static ProcessWrapper run(Class<?> type, String... arguments) throws IOException {
-		return run(createDirectory(asDirectoryName(type)), type, arguments);
-	}
-
 	protected static ProcessWrapper run(File workingDirectory, Class<?> type, String... arguments) throws IOException {
 		return isProcessRunAuto() ? launch(createDirectory(workingDirectory), type, arguments) : null;
-	}
-
-	protected static ProcessWrapper run(String classpath, Class<?> type, String... arguments) throws IOException {
-		return run(createDirectory(asDirectoryName(type)), classpath, type, arguments);
 	}
 
 	protected static ProcessWrapper run(File workingDirectory, String classpath, Class<?> type, String... arguments)

--- a/src/test/resources/log4j2-test-info.xml
+++ b/src/test/resources/log4j2-test-info.xml
@@ -1,0 +1,21 @@
+<Configuration status="error">
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %msg%n"/>
+		</Console>
+		<File name="File" fileName="build/logs/spring-test.log">
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{1.} - %msg%n"/>
+		</File>
+		<Null name="nop"/>
+	</Appenders>
+	<Loggers>
+		<Logger name="org.apache.geode" level="info"/>
+		<Logger name="org.springframework" level="error"/>
+		<Logger name="org.springframework.data.gemfire.listener.adapter.ContinuousQueryListenerAdapter" level="off" additivity="false"/>
+		<Logger name="org.springframework.data.gemfire.support.SpringContextBootstrappingInitializer" level="off" additivity="false"/>
+		<Root level="error">
+			<AppenderRef ref="Console"/>
+<!--			<AppenderRef ref="File"/>-->
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
- Use TemporaryFolder in various places that are using user.dir. This
  allows for cleaner separation of workspaces for each test as well as
  avoiding writing test artifacts into the working directory.
- Fix problem in `CacheClusterConfigurationIntegrationTest`. The
  introduction of `log4j2-test.xml` resulted in no output being produced
  by the started locator. Subsequent test post-processing relies on
  obtaining the locator log either via a registered output stream
  callback or, as fallback, by digging around for a log file. Since no
  output was being sent from the locator process, and no actual locator
  log was being produced, the `locatorView.log` file was being used as the
  output source. Occasionally this test would fail as this file wasn't
  being produced in time for the test completion to find it, thus
  failing because of 'no log output found'. Introduce a new log4j config
  file that is used specifically by this test to ensure locator output
  generation.
- Fix ability to attach debugger to `ProcessExecutor` launched processes.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You created a [JIRA](https://jira.spring.io/browse/DATAGEODE) ticket in the bug tracker for the project.
- [X] You formatted the code according to the source code style provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have specifically applied them to your changes. Do not submit any formatting related changes.
- [X] You submitted test cases (Unit or Integration Tests) backing your changes.
- [X] You added yourself as the author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
- [ ] If applicable, you have complied with and taken steps necessary to report any security vulnerabilities at [Pivotal Security Reporting](https://pivotal.io/security#reporting).
