### PR TITLE
DATAGEODE-218: Amended GatewayReceiverConfigurer to use LazyResolving…

### DIFF
--- a/src/main/java/org/springframework/data/gemfire/config/annotation/LazyResolvingComposableGatewayReceiverConfigurer.java
+++ b/src/main/java/org/springframework/data/gemfire/config/annotation/LazyResolvingComposableGatewayReceiverConfigurer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.gemfire.config.annotation;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.data.gemfire.config.annotation.support.AbstractLazyResolvingComposableConfigurer;
+import org.springframework.data.gemfire.wan.GatewayReceiverFactoryBean;
+import org.springframework.lang.Nullable;
+
+/**
+ * Composition of {@link GatewayReceiverConfigurer}.
+ *
+ * @author Udo Kohlmeyer
+ * @see GatewayReceiverFactoryBean
+ * @see GatewayReceiverConfigurer
+ * @see AbstractLazyResolvingComposableConfigurer
+ * @since 2.2.0
+ */
+public class LazyResolvingComposableGatewayReceiverConfigurer
+	extends AbstractLazyResolvingComposableConfigurer<GatewayReceiverFactoryBean, GatewayReceiverConfigurer>
+	implements GatewayReceiverConfigurer {
+
+	public static LazyResolvingComposableGatewayReceiverConfigurer create() {
+		return create(null);
+	}
+
+	public static LazyResolvingComposableGatewayReceiverConfigurer create(@Nullable BeanFactory beanFactory) {
+		return new LazyResolvingComposableGatewayReceiverConfigurer().with(beanFactory);
+	}
+
+	@Override
+	protected Class<GatewayReceiverConfigurer> getConfigurerType() {
+		return GatewayReceiverConfigurer.class;
+	}
+}

--- a/src/main/java/org/springframework/data/gemfire/wan/GatewayReceiverFactoryBean.java
+++ b/src/main/java/org/springframework/data/gemfire/wan/GatewayReceiverFactoryBean.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.gemfire.wan;
 
+import static java.util.stream.StreamSupport.stream;
+import static org.springframework.data.gemfire.util.CollectionUtils.nullSafeIterable;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +27,6 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewayReceiverFactory;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
-
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.gemfire.config.annotation.GatewayReceiverConfigurer;
@@ -59,7 +61,7 @@ public class GatewayReceiverFactoryBean extends AbstractWANComponentFactoryBean<
 	private Integer startPort;
 
 	@Autowired(required = false)
-	private GatewayReceiverConfigurer gatewayReceiverConfigurer;
+	private List<GatewayReceiverConfigurer> gatewayReceiverConfigurers;
 
 	@Autowired(required = false)
 	private List<GatewayTransportFilter> transportFilters;
@@ -83,7 +85,8 @@ public class GatewayReceiverFactoryBean extends AbstractWANComponentFactoryBean<
 
 		GatewayReceiverFactory gatewayReceiverFactory = this.cache.createGatewayReceiverFactory();
 
-		Optional.ofNullable(this.gatewayReceiverConfigurer).ifPresent(it -> it.configure(getName(),this));
+		stream(nullSafeIterable(this.gatewayReceiverConfigurers).spliterator(), false)
+			.forEach(it -> it.configure(getName(), this));
 
 		Optional.ofNullable(this.bindAddress)
 			.filter(StringUtils::hasText)
@@ -132,8 +135,8 @@ public class GatewayReceiverFactoryBean extends AbstractWANComponentFactoryBean<
 		this.gatewayReceiver = gatewayReceiver;
 	}
 
-	public void setGatewayReceiverConfigurer(GatewayReceiverConfigurer gatewayReceiverConfigurer) {
-		this.gatewayReceiverConfigurer = gatewayReceiverConfigurer;
+	public void setGatewayReceiverConfigurers(List<GatewayReceiverConfigurer> gatewayReceiverConfigurers) {
+		this.gatewayReceiverConfigurers = gatewayReceiverConfigurers;
 	}
 
 	public void setBindAddress(String bindAddress) {


### PR DESCRIPTION
Amended GatewayReceiverConfigurer to use LazyResolvingComposableGatewayReceiverConfigurer.java.

Also, amended GatewayReceiverFactoryBean.java to now define List<GatewayReceiverConfigurer> rather than single.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You created a [JIRA](https://jira.spring.io/browse/DATAGEODE) ticket in the bug tracker for the project.
- [x] You formatted the code according to the source code style provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have specifically applied them to your changes. Do not submit any formatting related changes.
- [x] You submitted test cases (Unit or Integration Tests) backing your changes.
- [x] You added yourself as the author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
- [x] If applicable, you have complied with and taken steps necessary to report any security vulnerabilities at [Pivotal Security Reporting](https://pivotal.io/security#reporting).
