### PR TITLE
DATAGEODE-283: Parse standard "host:port" format.

### DIFF
--- a/spring-data-geode/src/main/java/org/springframework/data/gemfire/support/ConnectionEndpoint.java
+++ b/spring-data-geode/src/main/java/org/springframework/data/gemfire/support/ConnectionEndpoint.java
@@ -82,7 +82,7 @@ public class ConnectionEndpoint implements Cloneable, Comparable<ConnectionEndpo
 		String host = StringUtils.trimAllWhitespace(hostPort);
 
 		int port = defaultPort;
-		int portIndex = host.indexOf("[");
+		int portIndex = indexOfPort(host);
 
 		if (portIndex > -1) {
 			port = parsePort(parseDigits(host.substring(portIndex)), defaultPort);
@@ -90,6 +90,16 @@ public class ConnectionEndpoint implements Cloneable, Comparable<ConnectionEndpo
 		}
 
 		return new ConnectionEndpoint(host, port);
+	}
+
+	static int indexOfPort(String host) {
+		for (int i = 0; i < host.length(); ++i) {
+			char c = host.charAt(i);
+			if (':' == c || '[' == c) {
+				return i;
+			}
+		}
+		return -1;
 	}
 
 	static String parseDigits(String value) {

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/support/ConnectionEndpointUnitTests.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/support/ConnectionEndpointUnitTests.java
@@ -16,6 +16,7 @@
 package org.springframework.data.gemfire.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetSocketAddress;
 
@@ -61,6 +62,22 @@ public class ConnectionEndpointUnitTests {
 	}
 
 	@Test
+	public void parseUsingDefaultHostAndDefaultPortWithColon() {
+
+		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse(":");
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo(ConnectionEndpoint.DEFAULT_HOST);
+		assertThat(connectionEndpoint.getPort()).isEqualTo(ConnectionEndpoint.DEFAULT_PORT);
+
+		connectionEndpoint = ConnectionEndpoint.parse(":", 1234);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo(ConnectionEndpoint.DEFAULT_HOST);
+		assertThat(connectionEndpoint.getPort()).isEqualTo(1234);
+	}
+
+	@Test
 	public void parseWithHostPort() {
 
 		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse("skullbox[12345]", 80);
@@ -83,9 +100,41 @@ public class ConnectionEndpointUnitTests {
 	}
 
 	@Test
+	public void parseWithHostPortWithColon() {
+
+		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse("skullbox:12345", 80);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("skullbox");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(12345);
+
+		connectionEndpoint = ConnectionEndpoint.parse("localhost:0", 8080);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("localhost");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(0);
+
+		connectionEndpoint = ConnectionEndpoint.parse("jambox:1O1O1", 443);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("jambox");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(111);
+	}
+
+	@Test
 	public void parseWithHostPortHavingSpacing() {
 
 		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse(" saturn  [1  23 4 ]");
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("saturn");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(1234);
+	}
+
+	@Test
+	public void parseWithHostPortHavingSpacingWithColon() {
+
+		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse(" saturn  :1  23 4 ");
 
 		assertThat(connectionEndpoint).isNotNull();
 		assertThat(connectionEndpoint.getHost()).isEqualTo("saturn");
@@ -140,9 +189,66 @@ public class ConnectionEndpointUnitTests {
 	}
 
 	@Test
+	public void parseWithHostUsingDefaultPortWithColon() {
+
+		ConnectionEndpoint connectionEndpoint =
+				ConnectionEndpoint.parse("mercury:oneTwoThreeFourFive", 80);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("mercury");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(80);
+
+		connectionEndpoint = ConnectionEndpoint.parse("venus:OxCAFEBABE", 443);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("venus");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(443);
+
+		connectionEndpoint = ConnectionEndpoint.parse("jupiter:#(^$)*!", 21);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("jupiter");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(21);
+
+		connectionEndpoint = ConnectionEndpoint.parse("saturn:", 22);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("saturn");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(22);
+
+		connectionEndpoint = ConnectionEndpoint.parse("uranis:", 23);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("uranis");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(23);
+
+		connectionEndpoint = ConnectionEndpoint.parse("neptune", 25);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("neptune");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(25);
+
+		connectionEndpoint = ConnectionEndpoint.parse("pluto");
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo("pluto");
+		assertThat(connectionEndpoint.getPort()).isEqualTo(ConnectionEndpoint.DEFAULT_PORT);
+	}
+
+	@Test
 	public void parseWithPortUsingDefaultHost() {
 
 		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse("[12345]", 80);
+
+		assertThat(connectionEndpoint).isNotNull();
+		assertThat(connectionEndpoint.getHost()).isEqualTo(ConnectionEndpoint.DEFAULT_HOST);
+		assertThat(connectionEndpoint.getPort()).isEqualTo(12345);
+	}
+
+	@Test
+	public void parseWithPortUsingDefaultHostWithColon() {
+
+		ConnectionEndpoint connectionEndpoint = ConnectionEndpoint.parse(":12345", 80);
 
 		assertThat(connectionEndpoint).isNotNull();
 		assertThat(connectionEndpoint.getHost()).isEqualTo(ConnectionEndpoint.DEFAULT_HOST);
@@ -207,6 +313,19 @@ public class ConnectionEndpointUnitTests {
 
 			throw expected;
 		}
+	}
+
+	@Test
+	public void indexOfPort() {
+		assertThat(ConnectionEndpoint.indexOfPort("")).isEqualTo(-1);
+		assertThat(ConnectionEndpoint.indexOfPort("a")).isEqualTo(-1);
+		assertThat(ConnectionEndpoint.indexOfPort(":")).isEqualTo(0);
+		assertThat(ConnectionEndpoint.indexOfPort("a:")).isEqualTo(1);
+		assertThat(ConnectionEndpoint.indexOfPort(":a")).isEqualTo(0);
+		assertThat(ConnectionEndpoint.indexOfPort("a:b")).isEqualTo(1);
+		assertThat(ConnectionEndpoint.indexOfPort("ab:")).isEqualTo(2);
+		assertThat(ConnectionEndpoint.indexOfPort("ab:c")).isEqualTo(2);
+		assertThatThrownBy(() -> ConnectionEndpoint.indexOfPort(null)).isInstanceOf(NullPointerException.class);
 	}
 
 	@Test


### PR DESCRIPTION
Adds support for standard "host:port" format when parsing
ConnectionEndpoints while preserving "host[port]" support.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You created a [JIRA](https://jira.spring.io/browse/DATAGEODE) ticket in the bug tracker for the project.
- [ ] You formatted the code according to the source code style provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have specifically applied them to your changes. Do not submit any formatting related changes.
- [ ] You submitted test cases (Unit or Integration Tests) backing your changes.
- [ ] You added yourself as the author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
- [ ] If applicable, you have complied with and taken steps necessary to report any security vulnerabilities at [Pivotal Security Reporting](https://pivotal.io/security#reporting).
