### PR TITLE
DATAGEODE-353 - Update package name for RestoreRedundancyResults in StubResourceManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
+<!--
 		<repository>
 			<id>geode-snapshot</id>
 			<name>Apache Geode Snapshots</name>
@@ -70,6 +71,7 @@
 				<enabled>true</enabled>
 			</releases>
 		</repository>
+-->
 <!--
 		<repository>
 			<id>apache-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,17 @@
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
+		<repository>
+			<id>geode-snapshot</id>
+			<name>Apache Geode Snapshots</name>
+			<url>https://maven.apachegeode-ci.info/snapshots</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
 <!--
 		<repository>
 			<id>apache-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
-<!--
 		<repository>
 			<id>geode-snapshot</id>
 			<name>Apache Geode Snapshots</name>
@@ -71,7 +70,6 @@
 				<enabled>true</enabled>
 			</releases>
 		</repository>
--->
 <!--
 		<repository>
 			<id>apache-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-geode-parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-NEXT-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data for Apache Geode and Pivotal GemFire</name>

--- a/spring-data-gemfire/pom.xml
+++ b/spring-data-gemfire/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-geode-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-NEXT-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-gemfire</artifactId>

--- a/spring-data-geode-distribution/pom.xml
+++ b/spring-data-geode-distribution/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-geode-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-NEXT-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-geode-distribution</artifactId>

--- a/spring-data-geode/pom.xml
+++ b/spring-data-geode/pom.xml
@@ -54,6 +54,13 @@
 
 		<dependency>
 			<groupId>org.apache.geode</groupId>
+			<artifactId>geode-gfsh</artifactId>
+			<version>${geode.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.geode</groupId>
 			<artifactId>geode-lucene</artifactId>
 			<version>${geode.version}</version>
 		</dependency>

--- a/spring-data-geode/pom.xml
+++ b/spring-data-geode/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<project.root>${basedir}/..</project.root>
-		<geode.version>1.12.0</geode.version>
+		<geode.version>1.13.0-SNAPSHOT</geode.version>
 	</properties>
 
 	<dependencies>

--- a/spring-data-geode/pom.xml
+++ b/spring-data-geode/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-geode-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-NEXT-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-geode</artifactId>

--- a/spring-data-geode/pom.xml
+++ b/spring-data-geode/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<project.root>${basedir}/..</project.root>
-		<geode.version>1.13.0-SNAPSHOT</geode.version>
+		<geode.version>[1.14,1.15)</geode.version>
 	</properties>
 
 	<dependencies>

--- a/spring-data-geode/src/main/java/org/springframework/data/gemfire/client/PoolAdapter.java
+++ b/spring-data-geode/src/main/java/org/springframework/data/gemfire/client/PoolAdapter.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  *
  */
-
 package org.springframework.data.gemfire.client;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
 import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.SocketFactory;
 import org.apache.geode.cache.query.QueryService;
 
 /**
@@ -106,6 +106,11 @@ public abstract class PoolAdapter implements Pool {
 		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
+	@Override
+	public int getServerConnectionTimeout() {
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+	}
+
 	public String getServerGroup() {
 		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
@@ -119,6 +124,10 @@ public abstract class PoolAdapter implements Pool {
 	}
 
 	public int getSocketConnectTimeout() {
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+	}
+
+	public SocketFactory getSocketFactory() {
 		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2010-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.gemfire;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.apache.geode.cache.CacheListener;
+import org.apache.geode.cache.CacheLoader;
+import org.apache.geode.cache.CacheLoaderException;
+import org.apache.geode.cache.CacheWriter;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.CustomExpiry;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAlgorithm;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.LoaderHelper;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.asyncqueue.AsyncEvent;
+import org.apache.geode.cache.asyncqueue.AsyncEventListener;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StringUtils;
+
+/**
+ * The LookupRegionMutationIntegrationTest class is a test suite of test cases testing the contract and integrated
+ * functionality between natively-defined GemFire Cache Regions and SDG's Region lookup functionality combined with
+ * Region attribute(s) mutation.
+ *
+ * @author John Blum
+ * @see Test
+ * @see RunWith
+ * @see LookupRegionFactoryBean
+ * @see ContextConfiguration
+ * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @since 1.7.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+@SuppressWarnings("unused")
+public class LookupPartitionRegionMutationIntegrationTest {
+
+	@Resource(name = "Example")
+	private Region<?, ?> example;
+
+	private void assertCacheListeners(CacheListener[] cacheListeners, Collection<String> expectedCacheListenerNames) {
+
+		if (!expectedCacheListenerNames.isEmpty()) {
+			assertNotNull("CacheListeners must not be null!", cacheListeners);
+			assertEquals(expectedCacheListenerNames.size(), cacheListeners.length);
+			assertTrue(toStrings(cacheListeners).containsAll(expectedCacheListenerNames));
+		}
+	}
+
+	private void assertEvictionAttributes(EvictionAttributes evictionAttributes, EvictionAction expectedAction,
+		EvictionAlgorithm expectedAlgorithm, int expectedMaximum) {
+
+		assertNotNull("EvictionAttributes must not be null!", evictionAttributes);
+		assertEquals(expectedAction, evictionAttributes.getAction());
+		assertEquals(expectedAlgorithm, evictionAttributes.getAlgorithm());
+		assertEquals(expectedMaximum, evictionAttributes.getMaximum());
+	}
+
+	private void assertExpirationAttributes(ExpirationAttributes expirationAttributes,
+
+		String description, int expectedTimeout, ExpirationAction expectedAction) {
+
+		assertNotNull(String.format("ExpirationAttributes for '%1$s' must not be null!", description),
+			expirationAttributes);
+		assertEquals(expectedAction, expirationAttributes.getAction());
+		assertEquals(expectedTimeout, expirationAttributes.getTimeout());
+	}
+
+	private void assertGatewaySenders(Region<?, ?> region, List<String> expectedGatewaySenderIds) {
+
+		assertNotNull(region.getAttributes());
+		assertNotNull(region.getAttributes().getGatewaySenderIds());
+		assertEquals(expectedGatewaySenderIds.size(), region.getAttributes().getGatewaySenderIds().size());
+		assertTrue(expectedGatewaySenderIds.containsAll(region.getAttributes().getGatewaySenderIds()));
+	}
+
+	private void assertGemFireComponent(Object gemfireComponent, String expectedName) {
+
+		assertNotNull("The GemFire component must not be null!", gemfireComponent);
+		assertEquals(expectedName, gemfireComponent.toString());
+	}
+
+	private void assertRegionAttributes(Region<?, ?> region, String expectedName, DataPolicy expectedDataPolicy) {
+
+		assertRegionAttributes(region, expectedName, String.format("%1$s%2$s", Region.SEPARATOR, expectedName),
+			expectedDataPolicy);
+	}
+
+	private void assertRegionAttributes(Region<?, ?> region, String expectedName, String expectedFullPath,
+		DataPolicy expectedDataPolicy) {
+
+		assertNotNull(String.format("'%1$s' Region was not properly initialized!", region));
+		assertEquals(expectedName, region.getName());
+		assertEquals(expectedFullPath, region.getFullPath());
+		assertNotNull(region.getAttributes());
+		assertEquals(expectedDataPolicy, region.getAttributes().getDataPolicy());
+	}
+
+	private Collection<String> toStrings(Object[] objects) {
+
+		List<String> cacheListenerNames = new ArrayList<>(objects.length);
+
+		for (Object object : objects) {
+			cacheListenerNames.add(object.toString());
+		}
+
+		return cacheListenerNames;
+	}
+
+	/**
+	 * @see <a href="https://issues.apache.org/jira/browse/GEODE-5039">EvictionAttributesMutator.setMaximum does not work</a>
+	 */
+	@Test
+	public void regionConfigurationIsCorrect() {
+
+		assertRegionAttributes(example, "Example", DataPolicy.PARTITION);
+		assertEquals(13, example.getAttributes().getInitialCapacity());
+		assertEquals(0.85f, example.getAttributes().getLoadFactor(), 0.0f);
+		assertCacheListeners(example.getAttributes().getCacheListeners(), Arrays.asList("A", "B"));
+		assertGemFireComponent(example.getAttributes().getCacheLoader(), "C");
+		assertGemFireComponent(example.getAttributes().getCacheWriter(), "D");
+		assertEvictionAttributes(example.getAttributes().getEvictionAttributes(), EvictionAction.OVERFLOW_TO_DISK,
+			EvictionAlgorithm.LRU_ENTRY, 1000);
+		assertGemFireComponent(example.getAttributes().getCustomEntryIdleTimeout(), "E");
+		assertNotNull(example.getAttributes().getAsyncEventQueueIds());
+		assertEquals(1, example.getAttributes().getAsyncEventQueueIds().size());
+		assertEquals("AEQ", example.getAttributes().getAsyncEventQueueIds().iterator().next());
+		assertGatewaySenders(example, Collections.singletonList("GWS"));
+	}
+
+	interface Nameable extends BeanNameAware {
+
+		String getName();
+
+		void setName(String name);
+	}
+
+	static abstract class AbstractNameable implements Nameable {
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
+		@Override
+		public void setBeanName(final String name) {
+			if (!StringUtils.hasText(this.name)) {
+				setName(name);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+	}
+
+	public static final class TestAsyncEventListener extends AbstractNameable implements AsyncEventListener {
+
+		@Override
+		public boolean processEvents(List<AsyncEvent> events) {
+			throw new UnsupportedOperationException("Not Implemented!");
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+	public static final class TestCacheListener<K, V> extends CacheListenerAdapter<K, V> implements Nameable {
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
+		@Override
+		public void setBeanName(final String name) {
+			if (!StringUtils.hasText(this.name)) {
+				setName(name);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return getName();
+		}
+	}
+
+	public static final class TestCacheLoader<K, V> extends AbstractNameable implements CacheLoader<K, V> {
+
+		@Override
+		public V load(LoaderHelper<K, V> helper) throws CacheLoaderException {
+			throw new UnsupportedOperationException("Not Implemented!");
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+	public static final class TestCacheWriter<K, V> extends AbstractNameable implements CacheWriter<K, V> {
+
+		@Override
+		public void beforeUpdate(EntryEvent<K, V> event) throws CacheWriterException {
+		}
+
+		@Override
+		public void beforeCreate(EntryEvent<K, V> event) throws CacheWriterException {
+		}
+
+		@Override
+		public void beforeDestroy(EntryEvent<K, V> event) throws CacheWriterException {
+		}
+
+		@Override
+		public void beforeRegionDestroy(RegionEvent<K, V> event) throws CacheWriterException {
+		}
+
+		@Override
+		public void beforeRegionClear(RegionEvent<K, V> event) throws CacheWriterException {
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+	public static final class TestCustomExpiry<K, V> extends AbstractNameable implements CustomExpiry<K, V> {
+
+		@Override
+		public ExpirationAttributes getExpiry(Region.Entry<K, V> entry) {
+			throw new UnsupportedOperationException("Not Implemented!");
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.gemfire;
 
 import static org.junit.Assert.assertEquals;
@@ -27,6 +26,9 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.CacheListener;
 import org.apache.geode.cache.CacheLoader;
@@ -47,23 +49,21 @@ import org.apache.geode.cache.RegionEvent;
 import org.apache.geode.cache.asyncqueue.AsyncEvent;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.util.CacheListenerAdapter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StringUtils;
 
 /**
- * The LookupRegionMutationIntegrationTest class is a test suite of test cases testing the contract and integrated
- * functionality between natively-defined GemFire Cache Regions and SDG's Region lookup functionality combined with
- * Region attribute(s) mutation.
+ * Integration Tests for {@link DataPolicy#PARTITION} {@link Region} {@link Region#getAttributesMutator() mutation}
+ * using SDG's {@literal lookup} {@link Region} functionality.
  *
+ * @author Udo Kohlmeyer
  * @author John Blum
- * @see Test
- * @see RunWith
- * @see LookupRegionFactoryBean
- * @see ContextConfiguration
+ * @see org.junit.Test
+ * @see org.springframework.data.gemfire.LookupRegionFactoryBean
+ * @see org.springframework.test.context.ContextConfiguration
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  * @since 1.7.0
  */
@@ -75,7 +75,8 @@ public class LookupPartitionRegionMutationIntegrationTest {
 	@Resource(name = "Example")
 	private Region<?, ?> example;
 
-	private void assertCacheListeners(CacheListener[] cacheListeners, Collection<String> expectedCacheListenerNames) {
+	private void assertCacheListeners(CacheListener<?, ?>[] cacheListeners,
+			Collection<String> expectedCacheListenerNames) {
 
 		if (!expectedCacheListenerNames.isEmpty()) {
 			assertNotNull("CacheListeners must not be null!", cacheListeners);
@@ -85,7 +86,7 @@ public class LookupPartitionRegionMutationIntegrationTest {
 	}
 
 	private void assertEvictionAttributes(EvictionAttributes evictionAttributes, EvictionAction expectedAction,
-		EvictionAlgorithm expectedAlgorithm, int expectedMaximum) {
+			EvictionAlgorithm expectedAlgorithm, int expectedMaximum) {
 
 		assertNotNull("EvictionAttributes must not be null!", evictionAttributes);
 		assertEquals(expectedAction, evictionAttributes.getAction());
@@ -94,8 +95,7 @@ public class LookupPartitionRegionMutationIntegrationTest {
 	}
 
 	private void assertExpirationAttributes(ExpirationAttributes expirationAttributes,
-
-		String description, int expectedTimeout, ExpirationAction expectedAction) {
+			String description, int expectedTimeout, ExpirationAction expectedAction) {
 
 		assertNotNull(String.format("ExpirationAttributes for '%1$s' must not be null!", description),
 			expirationAttributes);
@@ -124,7 +124,7 @@ public class LookupPartitionRegionMutationIntegrationTest {
 	}
 
 	private void assertRegionAttributes(Region<?, ?> region, String expectedName, String expectedFullPath,
-		DataPolicy expectedDataPolicy) {
+			DataPolicy expectedDataPolicy) {
 
 		assertNotNull(String.format("'%1$s' Region was not properly initialized!", region));
 		assertEquals(expectedName, region.getName());
@@ -170,6 +170,7 @@ public class LookupPartitionRegionMutationIntegrationTest {
 		String getName();
 
 		void setName(String name);
+
 	}
 
 	static abstract class AbstractNameable implements Nameable {
@@ -205,8 +206,8 @@ public class LookupPartitionRegionMutationIntegrationTest {
 		}
 
 		@Override
-		public void close() {
-		}
+		public void close() { }
+
 	}
 
 	public static final class TestCacheListener<K, V> extends CacheListenerAdapter<K, V> implements Nameable {
@@ -242,35 +243,30 @@ public class LookupPartitionRegionMutationIntegrationTest {
 		}
 
 		@Override
-		public void close() {
-		}
+		public void close() { }
+
 	}
 
 	public static final class TestCacheWriter<K, V> extends AbstractNameable implements CacheWriter<K, V> {
 
 		@Override
-		public void beforeUpdate(EntryEvent<K, V> event) throws CacheWriterException {
-		}
+		public void beforeUpdate(EntryEvent<K, V> event) throws CacheWriterException { }
 
 		@Override
-		public void beforeCreate(EntryEvent<K, V> event) throws CacheWriterException {
-		}
+		public void beforeCreate(EntryEvent<K, V> event) throws CacheWriterException { }
 
 		@Override
-		public void beforeDestroy(EntryEvent<K, V> event) throws CacheWriterException {
-		}
+		public void beforeDestroy(EntryEvent<K, V> event) throws CacheWriterException { }
 
 		@Override
-		public void beforeRegionDestroy(RegionEvent<K, V> event) throws CacheWriterException {
-		}
+		public void beforeRegionDestroy(RegionEvent<K, V> event) throws CacheWriterException { }
 
 		@Override
-		public void beforeRegionClear(RegionEvent<K, V> event) throws CacheWriterException {
-		}
+		public void beforeRegionClear(RegionEvent<K, V> event) throws CacheWriterException { }
 
 		@Override
-		public void close() {
-		}
+		public void close() { }
+
 	}
 
 	public static final class TestCustomExpiry<K, V> extends AbstractNameable implements CustomExpiry<K, V> {
@@ -281,7 +277,7 @@ public class LookupPartitionRegionMutationIntegrationTest {
 		}
 
 		@Override
-		public void close() {
-		}
+		public void close() { }
+
 	}
 }

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.gemfire;
 
 import static org.junit.Assert.assertEquals;
@@ -27,6 +26,9 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.CacheListener;
 import org.apache.geode.cache.CacheLoader;
@@ -48,25 +50,21 @@ import org.apache.geode.cache.asyncqueue.AsyncEvent;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StringUtils;
 
 /**
- * The LookupRegionMutationIntegrationTest class is a test suite of test cases testing the contract and integrated
- * functionality between natively-defined GemFire Cache Regions and SDG's Region lookup functionality combined with
- * Region attribute(s) mutation.
+ * Integration Tests for {@link LookupRegionFactoryBean} testing the contract and integrated functionality between
+ * natively-defined GemFire/Geode cache {@link Region Regions} and SDG's {@link Region} lookup functionality
+ * combined with {@link org.apache.geode.cache.RegionAttributes} {@link Region#getAttributesMutator() mutation}.
  *
  * @author John Blum
  * @see org.junit.Test
- * @see org.junit.runner.RunWith
  * @see org.springframework.data.gemfire.LookupRegionFactoryBean
  * @see org.springframework.test.context.ContextConfiguration
- * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @see org.springframework.test.context.junit4.SpringRunner
  * @since 1.7.0
  */
 @RunWith(SpringRunner.class)
@@ -77,7 +75,7 @@ public class LookupRegionMutationIntegrationTest {
 	@Resource(name = "Example")
 	private Region<?, ?> example;
 
-	private void assertCacheListeners(CacheListener[] cacheListeners, Collection<String> expectedCacheListenerNames) {
+	private void assertCacheListeners(CacheListener<?, ?>[] cacheListeners, Collection<String> expectedCacheListenerNames) {
 
 		if (!expectedCacheListenerNames.isEmpty()) {
 			assertNotNull("CacheListeners must not be null!", cacheListeners);
@@ -204,11 +202,14 @@ public class LookupRegionMutationIntegrationTest {
 
 	public static final class TestAsyncEventListener extends AbstractNameable implements AsyncEventListener {
 
-		@Override public boolean processEvents(List<AsyncEvent> events) {
+		@Override
+		public boolean processEvents(List<AsyncEvent> events) {
 			throw new UnsupportedOperationException("Not Implemented!");
 		}
 
-		@Override public void close() { }
+		@Override
+		public void close() { }
+
 	}
 
 	public static final class TestCacheListener<K, V> extends CacheListenerAdapter<K, V> implements Nameable {
@@ -245,21 +246,29 @@ public class LookupRegionMutationIntegrationTest {
 
 		@Override
 		public void close() { }
+
 	}
 
 	public static final class TestCacheWriter<K, V> extends AbstractNameable implements CacheWriter<K, V> {
 
-		@Override public void beforeUpdate(EntryEvent<K, V> event) throws CacheWriterException { }
+		@Override
+		public void beforeUpdate(EntryEvent<K, V> event) throws CacheWriterException { }
 
-		@Override public void beforeCreate(EntryEvent<K, V> event) throws CacheWriterException { }
+		@Override
+		public void beforeCreate(EntryEvent<K, V> event) throws CacheWriterException { }
 
-		@Override public void beforeDestroy(EntryEvent<K, V> event) throws CacheWriterException { }
+		@Override
+		public void beforeDestroy(EntryEvent<K, V> event) throws CacheWriterException { }
 
-		@Override public void beforeRegionDestroy(RegionEvent<K, V> event) throws CacheWriterException { }
+		@Override
+		public void beforeRegionDestroy(RegionEvent<K, V> event) throws CacheWriterException { }
 
-		@Override public void beforeRegionClear(RegionEvent<K, V> event) throws CacheWriterException { }
+		@Override
+		public void beforeRegionClear(RegionEvent<K, V> event) throws CacheWriterException { }
 
-		@Override public void close() { }
+		@Override
+		public void close() { }
+
 	}
 
 	public static final class TestCustomExpiry<K, V> extends AbstractNameable implements CustomExpiry<K, V> {
@@ -271,5 +280,6 @@ public class LookupRegionMutationIntegrationTest {
 
 		@Override
 		public void close() { }
+
 	}
 }

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/test/StubResourceManager.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/test/StubResourceManager.java
@@ -14,22 +14,25 @@
  * limitations under the License.
  *
  */
-
 package org.springframework.data.gemfire.test;
+
+import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.control.RestoreRedundancyOperation;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
 
 /**
- * The StubResourceManager class...
- *
  * @author John Blum
- * @since 1.0.0
+ * @deprecated
  */
+@Deprecated
 public class StubResourceManager implements ResourceManager {
 
 	private float criticalHeapPercentage;
@@ -38,27 +41,27 @@ public class StubResourceManager implements ResourceManager {
 	private float evictionOffHeapPercentage;
 
 	@Override
-	public void setCriticalHeapPercentage(final float heapPercentage) {
+	public void setCriticalHeapPercentage(float heapPercentage) {
 		this.criticalHeapPercentage = heapPercentage;
 	}
 
 	@Override
 	public float getCriticalHeapPercentage() {
-		return criticalHeapPercentage;
+		return this.criticalHeapPercentage;
 	}
 
 	@Override
-	public void setCriticalOffHeapPercentage(final float offHeapPercentage) {
-		this.criticalHeapPercentage = offHeapPercentage;
+	public void setCriticalOffHeapPercentage(float offHeapPercentage) {
+		this.criticalOffHeapPercentage = offHeapPercentage;
 	}
 
 	@Override
 	public float getCriticalOffHeapPercentage() {
-		return criticalOffHeapPercentage;
+		return this.criticalOffHeapPercentage;
 	}
 
 	@Override
-	public void setEvictionHeapPercentage(final float heapPercentage) {
+	public void setEvictionHeapPercentage(float heapPercentage) {
 		this.evictionHeapPercentage = heapPercentage;
 	}
 
@@ -68,7 +71,7 @@ public class StubResourceManager implements ResourceManager {
 	}
 
 	@Override
-	public void setEvictionOffHeapPercentage(final float offHeapPercentage) {
+	public void setEvictionOffHeapPercentage(float offHeapPercentage) {
 		this.evictionOffHeapPercentage = offHeapPercentage;
 	}
 
@@ -87,4 +90,13 @@ public class StubResourceManager implements ResourceManager {
 		return Collections.emptySet();
 	}
 
+	@Override
+	public RestoreRedundancyOperation createRestoreRedundancyOperation() {
+		return mock(RestoreRedundancyOperation.class);
+	}
+
+	@Override
+	public Set<CompletableFuture<RestoreRedundancyResults>> getRestoreRedundancyFutures() {
+		return Collections.emptySet();
+	}
 }

--- a/spring-data-geode/src/test/java/org/springframework/data/gemfire/test/StubResourceManager.java
+++ b/spring-data-geode/src/test/java/org/springframework/data/gemfire/test/StubResourceManager.java
@@ -26,7 +26,7 @@ import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.cache.control.RestoreRedundancyOperation;
-import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.management.runtime.RestoreRedundancyResults;
 
 /**
  * @author John Blum

--- a/spring-data-geode/src/test/resources/lookup-partition-region-mutation-cache.xml
+++ b/spring-data-geode/src/test/resources/lookup-partition-region-mutation-cache.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cache xmlns="http://geode.apache.org/schema/cache"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://geode.apache.org/schema/cache https://geode.apache.org/schema/cache/cache-1.0.xsd"
+	   version="1.0">
+
+	<region name="Example">
+		<region-attributes data-policy="partition" cloning-enabled="false" initial-capacity="13" load-factor="0.85"
+						   statistics-enabled="true">
+			<eviction-attributes>
+				<lru-entry-count action="overflow-to-disk" maximum="500"/>
+			</eviction-attributes>
+		</region-attributes>
+	</region>
+
+</cache>

--- a/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest-context.xml
+++ b/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest-context.xml
@@ -11,7 +11,7 @@
 ">
 
 	<util:properties id="gemfireProperties">
-		<prop key="name">LookupRegionMutationIntegrationTest</prop>
+		<prop key="name">LookupPartitionRegionMutationIntegrationTest</prop>
 		<prop key="log-level">error</prop>
 	</util:properties>
 

--- a/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest-context.xml
+++ b/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupPartitionRegionMutationIntegrationTest-context.xml
@@ -15,7 +15,7 @@
 		<prop key="log-level">error</prop>
 	</util:properties>
 
-	<gfe:cache cache-xml-location="/lookup-region-mutation-cache.xml" properties-ref="gemfireProperties"/>
+	<gfe:cache cache-xml-location="/lookup-partition-region-mutation-cache.xml" properties-ref="gemfireProperties"/>
 
 	<bean id="B" class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest.TestCacheListener"/>
 
@@ -33,15 +33,15 @@
 			<bean class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest$TestCacheWriter"
 				  p:name="D"/>
 		</gfe:cache-writer>
-		<gfe:region-ttl timeout="120" action="LOCAL_DESTROY"/>
-		<gfe:region-tti timeout="60" action="INVALIDATE"/>
+		<!--		<gfe:region-ttl timeout="120" action="LOCAL_DESTROY"/>-->
+		<!--		<gfe:region-tti timeout="60" action="DESTROY"/>-->
 		<gfe:entry-ttl timeout="30" action="DESTROY"/>
 		<gfe:custom-entry-tti>
 			<bean class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest$TestCustomExpiry"
 				  p:name="E"/>
 		</gfe:custom-entry-tti>
 		<gfe:gateway-sender name="GWS" remote-distributed-system-id="123" manual-start="true"/>
-		<gfe:async-event-queue name="AEQ" persistent="false" parallel="false">
+		<gfe:async-event-queue name="AEQ" persistent="false" parallel="true" dispatcher-threads="8">
 			<gfe:async-event-listener>
 				<bean
 					class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest$TestAsyncEventListener"

--- a/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest-context.xml
+++ b/spring-data-geode/src/test/resources/org/springframework/data/gemfire/LookupRegionMutationIntegrationTest-context.xml
@@ -43,8 +43,7 @@
 		<gfe:gateway-sender name="GWS" remote-distributed-system-id="123" manual-start="true"/>
 		<gfe:async-event-queue name="AEQ" persistent="false" parallel="false">
 			<gfe:async-event-listener>
-				<bean
-					class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest$TestAsyncEventListener"
+				<bean class="org.springframework.data.gemfire.LookupRegionMutationIntegrationTest$TestAsyncEventListener"
 					p:name="F"/>
 			</gfe:async-event-listener>
 		</gfe:async-event-queue>


### PR DESCRIPTION
The RestoreRedundancyResults's package name changed. StubResourceManager needed to be updated with new locations

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You created a [JIRA](https://jira.spring.io/browse/DATAGEODE) ticket in the bug tracker for the project.
- [ ] You formatted the code according to the source code style provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have specifically applied them to your changes. Do not submit any formatting related changes.
- [ ] You submitted test cases (Unit or Integration Tests) backing your changes.
- [ ] You added yourself as the author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
- [ ] If applicable, you have complied with and taken steps necessary to report any security vulnerabilities at [Pivotal Security Reporting](https://pivotal.io/security#reporting).
