### PR TITLE
Update README to reflect switch to github issues

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,17 +125,17 @@ If you are just starting out with Spring, try one of the https://spring.io/guide
 * If you are upgrading, check out the https://docs.spring.io/spring-data/geode/docs/current/changelog.txt[changelog] for "`new and noteworthy`" features.
 * Ask a question - we monitor https://stackoverflow.com[stackoverflow.com] for questions tagged with https://stackoverflow.com/tags/spring-data[`spring-data-geode`].
 You can also chat with the community on https://gitter.im/spring-projects/spring-data[Gitter].
-* Report bugs with Spring Data for Apache Geode at https://jira.spring.io/browse/DATAGEODE[jira.spring.io/browse/DATAGEODE].
+* Report bugs with Spring Data for Apache Geode at https://github.com/spring-projects/spring-data-geode/issues[github.com/spring-projects/spring-data-geode/issues].
 
 == Reporting Issues
 
-Spring Data uses JIRA as issue tracking system to record bugs and feature requests. If you want to raise an issue, please follow the recommendations below:
+Spring Data uses github issues as issue tracking system to record bugs and feature requests. If you want to raise an issue, please follow the recommendations below:
 
 * Before you log a bug, please search the
-https://jira.spring.io/browse/DATAGEODE[issue tracker] to see if someone has already reported the problem.
-* If the issue doesn’t already exist, https://jira.spring.io/browse/DATAGEODE[create a new issue].
+https://github.com/spring-projects/spring-data-geode/issues[issue tracker] to see if someone has already reported the problem.
+* If the issue doesn’t already exist, https://github.com/spring-projects/spring-data-geode/issues[create a new issue].
 * Please provide as much information as possible with the issue report, we like to know the version of Spring Data that you are using and JVM version.
-* If you need to paste code, or include a stack trace use JIRA `{code}…{code}` escapes before and after your text.
+* If you need to paste code, or include a stack trace use markdown {backtick}{backtick}{backtick} escapes before and after your text.
 * If possible try to create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code.
 
 == Building from Source


### PR DESCRIPTION
This project has switched to using github issues. The README
should direct users to github instead of to JIRA.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
